### PR TITLE
Add a scraper for the EPA-EIA Crosswalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See below for exact commands and available arguments.
 
 ## 2010 Census GeoData
 
-`scrapy crawl census`
+`scrapy crawl censusdp1tract`
 
 No other options.
 
@@ -45,6 +45,12 @@ No other options.
 For full instructions:
 
 `epacems --help`
+
+## EPA-EIA Crosswalk
+
+ To collect the data and field descriptions:
+
+ `scrapy crawl epa-eia-crosswalk`
 
 ## EIA860
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ conda env create -f environment.yml
 conda activate pudl-scrapers
 ```
 
-If you don't want ot use conda, create a virtual environment and run:
+If you don't want to use conda, create a virtual environment and run:
 
 ```
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For full instructions:
 
  To collect the data and field descriptions:
 
- `scrapy crawl epa-eia-crosswalk`
+ `scrapy crawl epa_eia_crosswalk`
 
 ## EIA860
 

--- a/pudl_scrapers/items.py
+++ b/pudl_scrapers/items.py
@@ -98,7 +98,7 @@ class EpaIpm(DataFile):
 
 
 class EpaEiaCrosswalk(DataFile):
-    """The EPA-EIA Crosswalk excel file."""
+    """The EPA-EIA Crosswalk zip file."""
 
     def __repr__(self):
         return "EpaEiaCrosswalk('%s')" % self["save_path"]

--- a/pudl_scrapers/items.py
+++ b/pudl_scrapers/items.py
@@ -98,10 +98,10 @@ class EpaIpm(DataFile):
 
 
 class EpaEiaCrosswalk(DataFile):
-    """BLAH."""
+    """The EPA-EIA Crosswalk excel file."""
 
     def __repr__(self):
-        return blah
+        return "EpaEiaCrosswalk('%s')" % self["save_path"]
 
 
 class Cems(DataFile):

--- a/pudl_scrapers/items.py
+++ b/pudl_scrapers/items.py
@@ -19,8 +19,7 @@ class Eia860(DataFile):
     year = scrapy.Field(serializer=int)
 
     def __repr__(self):
-        return "Eia860(year=%d, save_path='%s')" % (
-            self["year"], self["save_path"])
+        return "Eia860(year=%d, save_path='%s')" % (self["year"], self["save_path"])
 
 
 class Eia860M(DataFile):
@@ -42,8 +41,7 @@ class Eia861(DataFile):
     year = scrapy.Field(serializer=int)
 
     def __repr__(self):
-        return "Eia861(year=%d, save_path='%s')" % (
-            self["year"], self["save_path"])
+        return "Eia861(year=%d, save_path='%s')" % (self["year"], self["save_path"])
 
 
 class Eia923(DataFile):
@@ -52,8 +50,7 @@ class Eia923(DataFile):
     year = scrapy.Field(serializer=int)
 
     def __repr__(self):
-        return "Eia923(year=%d, save_path='%s')" % (
-            self["year"], self["save_path"])
+        return "Eia923(year=%d, save_path='%s')" % (self["year"], self["save_path"])
 
 
 class Ferc1(DataFile):
@@ -62,8 +59,7 @@ class Ferc1(DataFile):
     year = scrapy.Field(serializer=int)
 
     def __repr__(self):
-        return "Ferc1(year=%d, save_path='%s')" % (
-            self["year"], self["save_path"])
+        return "Ferc1(year=%d, save_path='%s')" % (self["year"], self["save_path"])
 
 
 class Ferc714(DataFile):
@@ -95,7 +91,17 @@ class EpaIpm(DataFile):
 
     def __repr__(self):
         return "EpaIpm(version=%d, revision='%s', save_path='%s')" % (
-            self["version"], self["revision"].isoformat(), self["save_path"])
+            self["version"],
+            self["revision"].isoformat(),
+            self["save_path"],
+        )
+
+
+class EpaEiaCrosswalk(DataFile):
+    """BLAH."""
+
+    def __repr__(self):
+        return blah
 
 
 class Cems(DataFile):

--- a/pudl_scrapers/spiders/epa_eia_crosswalk.py
+++ b/pudl_scrapers/spiders/epa_eia_crosswalk.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class EpaEiaSpider(scrapy.Spider):
     """Spider for EPA-EIA Crosswalk."""
 
-    name = "epa-eia-crosswalk"
+    name = "epa_eia_crosswalk"
     allowed_domains = ["www.github.com/USEPA"]
 
     def start_requests(self):

--- a/pudl_scrapers/spiders/epa_eia_crosswalk.py
+++ b/pudl_scrapers/spiders/epa_eia_crosswalk.py
@@ -2,8 +2,7 @@
 Spider for EPA-EIA Crosswalk.
 
 This module include the required infromation to establish a scrapy spider for
-the EPA-EIA Crosswalk. It pulls both the Crosswalk csv file and the field
-descriptions csv.
+the EPA-EIA Crosswalk. It pulls the entire repo zip file from github.
 
 """
 
@@ -32,16 +31,11 @@ class EpaEiaSpider(scrapy.Spider):
         output_root = settings_output_dir / self.name
         self.output_dir = pudl_scrapers.helpers.new_output_dir(output_root)
 
-        urls = [
-            "https://github.com/USEPA/camd-eia-crosswalk/raw/master/epa_eia_crosswalk.csv",
-            "https://github.com/USEPA/camd-eia-crosswalk/raw/master/field_descriptions.csv",
-        ]
-
-        for url in urls:
-            yield Request(url)
+        yield Request(
+            "https://github.com/USEPA/camd-eia-crosswalk/archive/refs/heads/master.zip"
+        )
 
     def parse(self, response):
         """Parse the downloaded census zip file."""
-        filename = response.url.split("/")[-1]
-        path = self.output_dir / filename
+        path = self.output_dir / "epa_eia_crosswalk.zip"
         yield items.EpaEiaCrosswalk(data=response.body, save_path=path)

--- a/pudl_scrapers/spiders/epa_eia_crosswalk.py
+++ b/pudl_scrapers/spiders/epa_eia_crosswalk.py
@@ -1,0 +1,38 @@
+"""
+Spider for EPA-EIA Crosswalk.
+
+This module include the required infromation to establish a scrapy spider for
+the EPA-EIA Crosswalk.
+
+"""
+
+import logging
+from pathlib import Path
+
+import pudl_scrapers
+import scrapy
+from scrapy.http import Request
+
+
+class EpaEiaSpider(scrapy.Spider):
+    """Spider for EPA-EIA Crosswalk."""
+
+    name = "epa-eia-crosswalk"
+    allowed_domains = ["www.github.com/USEPA"]
+
+    def __init__(self, year=None, *args, **kwargs):
+        """Spider for scraping the EPA-EIA crosswalk."""
+        super().__init__(*args, **kwargs)
+
+    def start_requests(self):
+        """Finalize setup and yield the initializing request."""
+        # Spider settings are not available during __init__, so finalizing here
+        settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
+        output_root = settings_output_dir / self.name
+        self.output_dir = pudl_scrapers.helpers.new_output_dir(output_root)
+
+        yield Request("https://github.com/USEPA/camd-eia-crosswalk")
+
+
+    def parse(self, response):
+        

--- a/pudl_scrapers/spiders/epa_eia_crosswalk.py
+++ b/pudl_scrapers/spiders/epa_eia_crosswalk.py
@@ -2,7 +2,8 @@
 Spider for EPA-EIA Crosswalk.
 
 This module include the required infromation to establish a scrapy spider for
-the EPA-EIA Crosswalk.
+the EPA-EIA Crosswalk. It pulls both the Crosswalk csv file and the field
+descriptions csv.
 
 """
 
@@ -11,7 +12,11 @@ from pathlib import Path
 
 import pudl_scrapers
 import scrapy
+from pudl_scrapers import items
 from scrapy.http import Request
+
+
+logger = logging.getLogger(__name__)
 
 
 class EpaEiaSpider(scrapy.Spider):
@@ -31,8 +36,16 @@ class EpaEiaSpider(scrapy.Spider):
         output_root = settings_output_dir / self.name
         self.output_dir = pudl_scrapers.helpers.new_output_dir(output_root)
 
-        yield Request("https://github.com/USEPA/camd-eia-crosswalk")
+        urls = [
+            "https://github.com/USEPA/camd-eia-crosswalk/raw/master/epa_eia_crosswalk.csv",
+            "https://github.com/USEPA/camd-eia-crosswalk/raw/master/field_descriptions.csv",
+        ]
 
+        for url in urls:
+            yield Request(url)
 
     def parse(self, response):
-        
+        """Parse the downloaded census zip file."""
+        filename = response.url.split("/")[-1]
+        path = self.output_dir / filename
+        yield items.EpaEiaCrosswalk(data=response.body, save_path=path)

--- a/pudl_scrapers/spiders/epa_eia_crosswalk.py
+++ b/pudl_scrapers/spiders/epa_eia_crosswalk.py
@@ -25,10 +25,6 @@ class EpaEiaSpider(scrapy.Spider):
     name = "epa-eia-crosswalk"
     allowed_domains = ["www.github.com/USEPA"]
 
-    def __init__(self, year=None, *args, **kwargs):
-        """Spider for scraping the EPA-EIA crosswalk."""
-        super().__init__(*args, **kwargs)
-
     def start_requests(self):
         """Finalize setup and yield the initializing request."""
         # Spider settings are not available during __init__, so finalizing here


### PR DESCRIPTION
This is a draft PR so folks can follow along on my progress towards adding a EPA-EIA Crosswalk scraper. Note that there are several line changes because of the black formatter--not trying to be gnit-picky!

The scraper successfully downloads two files from the CAMD github page:
- epa_eia_crosswalk.csv
- field_descriptions.csv

**Questions**: 

Right now the scraper uses a direct link to download each of the files. I.e.: 
- "https://github.com/USEPA/camd-eia-crosswalk/raw/master/epa_eia_crosswalk.csv"
- "https://github.com/USEPA/camd-eia-crosswalk/raw/master/field_descriptions.csv"

1) Would it be more robust to start with the link to the main github page "https://github.com/USEPA/camd-eia-crosswalk" and work from there using xpaths to find the links to each of the files?

2) I decided against downloading the entire repo and then extracting the files I wanted, do you agree with this method?