### PR TITLE
Udate EPA-EIA crosswalk name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ For full instructions:
 
 No other options.
 
-## EPA CEMS unitid to EIA plant Crosswalk
+## EPA CAMD to EIA Crosswalk
 
 To collect the data and field descriptions:
 
- `scrapy crawl epacems_unitid_eia_plant_crosswalk`
+ `scrapy crawl epacamd_eia`
 
 ## EIA860
 

--- a/src/pudl_scrapers/items.py
+++ b/src/pudl_scrapers/items.py
@@ -75,12 +75,12 @@ class Ferc714(DataFile):
         return f"Ferc714('{self['save_path']}')"
 
 
-class EpaCemsUnitidEiaPlantCrosswalk(DataFile):
-    """The EPA CEMS unitid to EIA plant Crosswalk zip file."""
+class EpaCamdEia(DataFile):
+    """The EPA CAMD to EIA Crosswalk zip file."""
 
     def __repr__(self):
-        """String representation of the EPA CEMS to EIA Crosswalk data file."""
-        return f"EpaCemsUnitidEiaPlantCrosswalk('{self['save_path']}')"
+        """String representation of the EPA CAMD to EIA Crosswalk data file."""
+        return f"EpaCamdEia('{self['save_path']}')"
 
 
 class Cems(DataFile):

--- a/src/pudl_scrapers/spiders/epacamd_eia.py
+++ b/src/pudl_scrapers/spiders/epacamd_eia.py
@@ -1,7 +1,7 @@
-"""Spider for EPA CEMS unitid to EIA plant Crosswalk.
+"""Spider for EPA CAMD to EIA Crosswalk.
 
 This module include the required infromation to establish a scrapy spider for
-the EPA CEMS unitid to EIA plant Crosswalk. It pulls the entire repo zip file from
+the EPA CAMD to EIA Crosswalk. It pulls the entire repo zip file from
 github.
 
 """
@@ -18,10 +18,10 @@ from pudl_scrapers import items
 logger = logging.getLogger(__name__)
 
 
-class EpaCemsUnitidEiaPlantSpider(scrapy.Spider):
-    """Spider for EPA CEMS unitid to EIA plant Crosswalk."""
+class EpaCamdEiaSpider(scrapy.Spider):
+    """Spider for EPA CAMD to EIA Crosswalk."""
 
-    name = "epacems_unitid_eia_plant_crosswalk"
+    name = "epacamd_eia"
     allowed_domains = ["www.github.com/USEPA"]
 
     def start_requests(self):
@@ -37,5 +37,5 @@ class EpaCemsUnitidEiaPlantSpider(scrapy.Spider):
 
     def parse(self, response):
         """Parse the downloaded census zip file."""
-        path = self.output_dir / "epacems_unitid_eia_plant_crosswalk.zip"
-        yield items.EpaCemsUnitidEiaPlantCrosswalk(data=response.body, save_path=path)
+        path = self.output_dir / "epacamd_eia.zip"
+        yield items.EpaCamdEia(data=response.body, save_path=path)


### PR DESCRIPTION
Previously it was `epacems_unitid_eia_plant_crosswalk` which was long and did not include references to boiler and generator which are also included in the crosswalk. Also our current glue naming protocol is dataset1_dataset2. The new name is `epacamd_eia`