### PR TITLE
Create scrapers for historical FERC VisualFoxPro data

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,18 @@ To collect a specific year (eg, 2007):
 `scrapy crawl eia923 -a year=2007`
 
 
-## FERC Form 1
+## FERC Forms 1, 2, 6, & 60:
 
 To collect all the data:
 
-`scrapy crawl ferc1`
+```sh
+scrapy crawl ferc1
+scrapy crawl ferc2
+scrapy crawl ferc6
+scrapy crawl ferc60
+```
 
-To collect a specific year (eg, 2007):
-
-`scrapy crawl ferc1 -a year=2007`
+There are no subsets enabled.
 
 ## FERC 714
 To collect the data:

--- a/src/pudl_scrapers/items.py
+++ b/src/pudl_scrapers/items.py
@@ -67,6 +67,37 @@ class Ferc1(DataFile):
         return f"Ferc1(year={self['year']}, save_path='{self['save_path']}')"
 
 
+class Ferc2(DataFile):
+    """The Ferc2 forms in a zip file."""
+
+    year = scrapy.Field(serializer=int)
+    part = scrapy.Field(serializer=int)
+
+    def __repr__(self):
+        """String representation of a FERC-2 data file."""
+        return f"Ferc2(year={self['year']}, part={self['part']}, save_path='{self['save_path']}')"
+
+
+class Ferc6(DataFile):
+    """The FERC Form 6 in a zip file."""
+
+    year = scrapy.Field(serializer=int)
+
+    def __repr__(self):
+        """String representation of a FERC-6 data file."""
+        return f"Ferc6(year={self['year']}, save_path='{self['save_path']}')"
+
+
+class Ferc60(DataFile):
+    """The FERC Form 60 in a zip file."""
+
+    year = scrapy.Field(serializer=int)
+
+    def __repr__(self):
+        """String representation of a FERC-60 data file."""
+        return f"Ferc60(year={self['year']}, save_path='{self['save_path']}')"
+
+
 class Ferc714(DataFile):
     """The Ferc714 data zip file."""
 

--- a/src/pudl_scrapers/spiders/ferc1.py
+++ b/src/pudl_scrapers/spiders/ferc1.py
@@ -30,10 +30,10 @@ class Ferc1Spider(scrapy.Spider):
         self.year = year
 
     def start_requests(self):
-        """Start requesting Ferc 1 forms.
+        """Start requesting FERC 1 forms.
 
         Yields:
-            List of Requests for Ferc 1 forms
+            List of Requests for FERC 1 forms
         """
         # Spider settings are not available during __init__, so finalizing here
         settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
@@ -47,7 +47,7 @@ class Ferc1Spider(scrapy.Spider):
         yield from self.all_form_requests()
 
     def parse(self, response):
-        """Produce the Ferc1 item.
+        """Produce the FERC item.
 
         Args:
             response: scrapy.http.Response containing ferc1 data
@@ -79,5 +79,5 @@ class Ferc1Spider(scrapy.Spider):
         Yields:
             Requests for all available Ferc form 1 zip files
         """
-        for year in range(1994, 2021):
+        for year in range(1994, 2022):
             yield self.form_for_year(year)

--- a/src/pudl_scrapers/spiders/ferc1.py
+++ b/src/pudl_scrapers/spiders/ferc1.py
@@ -17,18 +17,6 @@ class Ferc1Spider(scrapy.Spider):
         "https://www.ferc.gov/general-information-0/electric-industry-forms/form-1-1-f-3-q-electric-historical-vfp-data"
     ]
 
-    def __init__(self, year=None, *args, **kwargs):
-        """Initialize the FERC-1 Spider."""
-        super().__init__(*args, **kwargs)
-
-        if year is not None:
-            year = int(year)
-
-            if year < 1994:
-                raise ValueError("Years before 1994 are not supported")
-
-        self.year = year
-
     def start_requests(self):
         """Start requesting FERC 1 forms.
 
@@ -39,10 +27,6 @@ class Ferc1Spider(scrapy.Spider):
         settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
         output_root = settings_output_dir / "ferc1"
         self.output_dir = new_output_dir(output_root)
-
-        if self.year is not None:
-            yield self.form_for_year(self.year)
-            return
 
         yield from self.all_form_requests()
 

--- a/src/pudl_scrapers/spiders/ferc1.py
+++ b/src/pudl_scrapers/spiders/ferc1.py
@@ -13,7 +13,9 @@ class Ferc1Spider(scrapy.Spider):
 
     name = "ferc1"
     allowed_domains = ["www.ferc.gov"]
-    start_urls = ["https://www.ferc.gov/docs-filing/forms/form-1/data.asp"]
+    start_urls = [
+        "https://www.ferc.gov/general-information-0/electric-industry-forms/form-1-1-f-3-q-electric-historical-vfp-data"
+    ]
 
     def __init__(self, year=None, *args, **kwargs):
         """Initialize the FERC-1 Spider."""
@@ -68,7 +70,7 @@ class Ferc1Spider(scrapy.Spider):
         Returns:
             Request for the Ferc 1 form
         """
-        url = f"ftp://eforms1.ferc.gov/f1allyears/f1_{year}.zip"
+        url = f"https://forms.ferc.gov/f1allyears/f1_{year}.zip"
         return Request(url, meta={"year": year}, callback=self.parse)
 
     def all_form_requests(self):

--- a/src/pudl_scrapers/spiders/ferc2.py
+++ b/src/pudl_scrapers/spiders/ferc2.py
@@ -1,0 +1,114 @@
+"""Scrapy spider for downloading historical FERC Form 2 Visual FoxPro data."""
+from pathlib import Path
+
+import scrapy
+from scrapy.http import Request
+
+from pudl_scrapers import items
+from pudl_scrapers.helpers import new_output_dir
+
+
+class Ferc2Spider(scrapy.Spider):
+    """Scrapy spider for downloading historical FERC Form 2 Visual FoxPro data."""
+
+    name = "ferc2"
+    allowed_domains = ["www.ferc.gov"]
+    start_urls = [
+        "https://www.ferc.gov/industries-data/natural-gas/industry-forms/form-2-2a-3-q-gas-historical-vfp-data"
+    ]
+
+    def start_requests(self):
+        """Start requesting FERC 2 forms.
+
+        Yields:
+            List of Requests for FERC 2 forms
+        """
+        # Spider settings are not available during __init__, so finalizing here
+        settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
+        output_root = settings_output_dir / "ferc2"
+        self.output_dir = new_output_dir(output_root)
+
+        yield from self.all_form_requests()
+
+    def parse(self, response):
+        """Produce the FERC 2 item.
+
+        Args:
+            response: scrapy.http.Response containing FERC Form 2 data
+
+        Yields:
+            FERC Form 2 item
+        """
+        if response.meta["part"] is None:
+            path = self.output_dir / f"ferc2-{response.meta['year']}.zip"
+        else:
+            path = (
+                self.output_dir
+                / f"ferc2-{response.meta['year']}-{response.meta['part']}.zip"
+            )
+
+        yield items.Ferc2(
+            data=response.body,
+            year=response.meta["year"],
+            part=response.meta["part"],
+            save_path=path,
+        )
+
+    def form_for_year_part(self, year: int, part: int | None = None):
+        """Produce a form request for the given year.
+
+        Args:
+            year: Reporting year of the data to be scraped.
+            part: In earlier years data is split into two parts (A-M, and N-Z) which
+                must be downloaded separately. Part indicates which one to get.
+
+        Returns:
+            Request for the FERC 2 form
+
+        """
+        early_urls: dict[tuple(int, int), str] = {
+            (1991, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y91A-M.zip",
+            (1991, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y91N-Z.zip",
+            (1992, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y92A-M.zip",
+            (1992, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y92N-Z.zip",
+            (1993, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y93A-M.zip",
+            (1993, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y93N-Z.zip",
+            (1994, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y94A-M.zip",
+            (1994, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y94N-Z.zip",
+            (1995, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y95A-M.zip",
+            (1995, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y95N-Z.zip",
+            (1996, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y96-1.zip",
+            (1996, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y96-2.zip",
+            (1997, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y97-1.zip",
+            (1997, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y97-2.zip",
+            (1998, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y98-1.zip",
+            (1998, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y98-2.zip",
+            (1999, 1): "https://www.ferc.gov/sites/default/files/2020-07/F2Y99-1.zip",
+            (1999, 2): "https://www.ferc.gov/sites/default/files/2020-07/F2Y99-2.zip",
+        }
+        # Special rules for grabbing the early two-part data:
+        if part is not None:
+            assert year >= 1991 and year <= 1999
+            url = early_urls[(year, part)]
+        else:
+            assert year >= 1996 and year <= 2021
+            url = f"https://forms.ferc.gov/f2allyears/f2_{year}.zip"
+
+        return Request(
+            url,
+            meta={"year": year, "part": part},
+            callback=self.parse,
+        )
+
+    def all_form_requests(self):
+        """Produces form requests for all supported years.
+
+        Yields:
+            Requests for all available FERC Form 2 zip files
+        """
+        for year in range(1991, 2000):
+            for part in [1, 2]:
+                yield self.form_for_year_part(year=year, part=part)
+
+        for year in range(1996, 2022):
+            yield self.form_for_year_part(year=year, part=None)

--- a/src/pudl_scrapers/spiders/ferc2.py
+++ b/src/pudl_scrapers/spiders/ferc2.py
@@ -88,10 +88,10 @@ class Ferc2Spider(scrapy.Spider):
         }
         # Special rules for grabbing the early two-part data:
         if part is not None:
-            assert year >= 1991 and year <= 1999
+            assert year >= 1991 and year <= 1999  # nosec: B101
             url = early_urls[(year, part)]
         else:
-            assert year >= 1996 and year <= 2021
+            assert year >= 1996 and year <= 2021  # nosec: B101
             url = f"https://forms.ferc.gov/f2allyears/f2_{year}.zip"
 
         return Request(

--- a/src/pudl_scrapers/spiders/ferc6.py
+++ b/src/pudl_scrapers/spiders/ferc6.py
@@ -1,0 +1,67 @@
+"""Scrapy spider for downloading FERC Form 6 data."""
+from pathlib import Path
+
+import scrapy
+from scrapy.http import Request
+
+from pudl_scrapers import items
+from pudl_scrapers.helpers import new_output_dir
+
+
+class Ferc6Spider(scrapy.Spider):
+    """Scrapy spider for downloading FERC Form 6 data."""
+
+    name = "ferc6"
+    allowed_domains = ["www.ferc.gov"]
+    start_urls = [
+        "https://www.ferc.gov/general-information-1/oil-industry-forms/form-6-6q-historical-vfp-data"
+    ]
+
+    def start_requests(self):
+        """Start requesting FERC 6 forms.
+
+        Yields:
+            List of Requests for FERC 6 forms
+        """
+        # Spider settings are not available during __init__, so finalizing here
+        settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
+        output_root = settings_output_dir / "ferc6"
+        self.output_dir = new_output_dir(output_root)
+
+        yield from self.all_form_requests()
+
+    def parse(self, response):
+        """Produce the FERC item.
+
+        Args:
+            response: scrapy.http.Response containing ferc6 data
+
+        Yields:
+            Ferc6 item
+        """
+        path = self.output_dir / f"ferc6-{response.meta['year']}.zip"
+
+        yield items.Ferc6(
+            data=response.body, year=response.meta["year"], save_path=path
+        )
+
+    def form_for_year(self, year: int):
+        """Produce a form request for the given year.
+
+        Args:
+            year: Report year of the data to scrape.
+
+        Returns:
+            Request for the Ferc 6 form
+        """
+        url = f"https://forms.ferc.gov/f6allyears/f6_{year}.zip"
+        return Request(url, meta={"year": year}, callback=self.parse)
+
+    def all_form_requests(self):
+        """Produces form requests for all supported years.
+
+        Yields:
+            Requests for all available FERC Form 6 zip files
+        """
+        for year in range(2000, 2022):
+            yield self.form_for_year(year)

--- a/src/pudl_scrapers/spiders/ferc60.py
+++ b/src/pudl_scrapers/spiders/ferc60.py
@@ -1,0 +1,67 @@
+"""Scrapy spider for downloading FERC Form 60 data."""
+from pathlib import Path
+
+import scrapy
+from scrapy.http import Request
+
+from pudl_scrapers import items
+from pudl_scrapers.helpers import new_output_dir
+
+
+class Ferc60Spider(scrapy.Spider):
+    """Scrapy spider for downloading FERC Form 60 data."""
+
+    name = "ferc60"
+    allowed_domains = ["www.ferc.gov"]
+    start_urls = [
+        "https://www.ferc.gov/filing-forms/service-companies-filing-forms/Form-60-Historical-VFP-Data"
+    ]
+
+    def start_requests(self):
+        """Start requesting FERC 60 forms.
+
+        Yields:
+            List of Requests for FERC 60 forms
+        """
+        # Spider settings are not available during __init__, so finalizing here
+        settings_output_dir = Path(self.settings.get("OUTPUT_DIR"))
+        output_root = settings_output_dir / "ferc60"
+        self.output_dir = new_output_dir(output_root)
+
+        yield from self.all_form_requests()
+
+    def parse(self, response):
+        """Produce the FERC item.
+
+        Args:
+            response: scrapy.http.Response containing FERC Form 60 data
+
+        Yields:
+            Ferc60 item
+        """
+        path = self.output_dir / f"ferc6-{response.meta['year']}.zip"
+
+        yield items.Ferc60(
+            data=response.body, year=response.meta["year"], save_path=path
+        )
+
+    def form_for_year(self, year: int):
+        """Produce a form request for the given year.
+
+        Args:
+            year: Report year of the data to scrape.
+
+        Returns:
+            Request for the Ferc 60 form
+        """
+        url = f"https://forms.ferc.gov/f60allyears/f60_{year}.zip"
+        return Request(url, meta={"year": year}, callback=self.parse)
+
+    def all_form_requests(self):
+        """Produces form requests for all supported years.
+
+        Yields:
+            Requests for all available FERC Form 60 zip files
+        """
+        for year in range(2006, 2021):
+            yield self.form_for_year(year)

--- a/tests/ferc1_test.py
+++ b/tests/ferc1_test.py
@@ -10,10 +10,10 @@ class TestFerc1:
         spider = Ferc1Spider()
         all_forms = list(spider.all_form_requests())
 
-        assert all_forms[0].url == "ftp://eforms1.ferc.gov/f1allyears/f1_1994.zip"
+        assert all_forms[0].url == "https://forms.ferc.gov/f1allyears/f1_1994.zip"
         assert all_forms[0].meta["year"] == 1994
 
-        assert all_forms[26].url == "ftp://eforms1.ferc.gov/f1allyears/" "f1_2020.zip"
+        assert all_forms[26].url == "https://forms.ferc.gov/f1allyears/f1_2020.zip"
         assert all_forms[26].meta["year"] == 2020
 
     def test_spider_gets_specific_year(self):
@@ -22,5 +22,5 @@ class TestFerc1:
 
         for year in range(1994, 2021):
             form_req = spider.form_for_year(year)
-            assert form_req.url == f"ftp://eforms1.ferc.gov/f1allyears/f1_{year}.zip"
+            assert form_req.url == f"https://forms.ferc.gov/f1allyears/f1_{year}.zip"
             assert form_req.meta["year"] == year

--- a/tests/ferc1_test.py
+++ b/tests/ferc1_test.py
@@ -20,7 +20,7 @@ class TestFerc1:
         """Ferc1 generates any individual form url."""
         spider = Ferc1Spider()
 
-        for year in range(1994, 2021):
+        for year in range(1994, 2022):
             form_req = spider.form_for_year(year)
             assert form_req.url == f"https://forms.ferc.gov/f1allyears/f1_{year}.zip"
             assert form_req.meta["year"] == year


### PR DESCRIPTION
Since I've been poking around in the scrapers and it's fresh in my mind, I went ahead and created scrapers for all the old Visual FoxPro DBF databases.

* FERC 1: updated to point at the new URLs.
* FERC 2: 1991-1999 as DAT files (split into 2 parts per year); 1996-2021Q2 as DBF
* FERC 6: 2000-2020 as DBF
* FERC 60: 2006-2020 as DBF

I simplified the FERC 1 scraper to only download all the years, rather than allowing one year at a time, and used that pattern for all of the other scrapers as well.

I didn't add tests for all of these basically identical scrapers. Looking at the FERC 1 tests they seemed kind of perfunctory. I'm not sure what the right kinds of tests are for these things... I guess we want to make sure that they actually get all of the available files, and that they keep working with the data out there in the real world.  Is that an integration test we should implement? Or is it the nature of the scrapers that we should just be running them for real on a regular basis, and when that usage breaks, we fix it?

Closes #41 